### PR TITLE
Delete Prsym-Dev Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "dependencies/prysm"]
 	path = dependencies/prysm
 	url = https://github.com/prysmaticlabs/prysm.git
-[submodule "dependencies/prysm-dev"]
-	path = dependencies/prysm-dev
-	url = https://github.com/prysmaticlabs/prysm.git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
 
 </div>
 
-This deployment process allows you to setup and deploy your own local ethereum PoS networks. Soon, you'll have the ability to configure the number of nodes you wish to run.
+This deployment process allows you to setup and deploy your own local ethereum PoS networks.
+This repository is targeted to developers who want to quickly modify client source code and deploy to a PoS network.
+This setup can is can serve as a reference for building your own production deployments but better solutions exist for [that](https://docs.kurtosis.com/how-to-compose-your-own-testnet/) use case.
+
 
 ## Installation
 This project utilizes Git submodules to reference the client code, notably Go-Ethereum and Prysm.
@@ -39,7 +42,7 @@ The script is idempotent and will clean up every time it is restarted.
 ```
 ![Generating a proof](./assets/runloop.gif)
 
-Reach out to me on Twitter @0xZorz if you have any issues. DMs are open
+Reach out to me on Twitter [@0xZorz](https://twitter.com/0xZorz) if you have any issues. DMs are open
 
 ## Acknowledgements
 

--- a/build-dependencies.sh
+++ b/build-dependencies.sh
@@ -6,11 +6,8 @@ set -exu
 set -o pipefail
 
 PRYSM_DIR=./dependencies/prysm
-PRYSM_DEV_DIR=./dependencies/prysm-dev
 GETH_DIR=./dependencies/go-ethereum
 
 ( cd $PRYSM_DIR && go build -o=./out/beacon-chain ./cmd/beacon-chain && go build -o=./out/validator ./cmd/validator && go build -o=./out/prysmctl ./cmd/prysmctl )
-
-( cd $PRYSM_DEV_DIR && go build -o=./out/beacon-chain ./cmd/beacon-chain && go build -o=./out/validator ./cmd/validator && go build -o=./out/prysmctl ./cmd/prysmctl )
 
 ( cd $GETH_DIR && make )

--- a/testnet.sh
+++ b/testnet.sh
@@ -15,7 +15,7 @@ mkdir -p $NETWORK_DIR/logs
 pkill geth || echo "No existing geth processes"
 
 GETH_BINARY=./dependencies/go-ethereum/build/bin/geth
-PRYSM_CTL_BINARY=./dependencies/prysm-dev/out/prysmctl
+PRYSM_CTL_BINARY=./dependencies/prysm/out/prysmctl
 PRYSM_BEACON_BINARY=./dependencies/prysm/out/beacon-chain
 PRYSM_VALIDATOR_BINARY=./dependencies/prysm/out/validator
 


### PR DESCRIPTION
The prysm-dev submodule was previously separated as it was believed that prysm ctl binary was broken on later commits. However, this was not the case.